### PR TITLE
pin nixos-rebuild to nixpkgs/23.11

### DIFF
--- a/nixos/main.tf
+++ b/nixos/main.tf
@@ -98,7 +98,7 @@ resource "null_resource" "deploy" {
       [ "nix",
         "--extra-experimental-features", "nix-command flakes",
         "shell",
-        "github:NixOS/nixpkgs/22.11#nixos-rebuild",
+        "github:NixOS/nixpkgs/23.11#nixos-rebuild",
         "--command",
         "nixos-rebuild",
         "--fast",


### PR DESCRIPTION
Using 22.11 seems to hit the issue described in
[this discussion](https://discourse.nixos.org/t/segmentation-fault-when-running-any-nix-program-sigsegv-exit-code-139/36659),
making it impossible to use this terraform provider in some cases on macOS running on
aarch64.

This pull request doesn't solve the root cause of the issue, but seems
to mitigate it by using a newer version of nixos-rebuild.
