### PR TITLE
Support nix 2.19

### DIFF
--- a/nixos/instantiate.sh
+++ b/nixos/instantiate.sh
@@ -5,4 +5,4 @@ set -euo pipefail
 
 FLAKE="${1}"
 
-nix path-info --json --derivation "${FLAKE}.config.system.build.toplevel" | jq '{ "path": .[0].path }'
+nix path-info --derivation "${FLAKE}.config.system.build.toplevel" | jq --raw-input '{ "path": . }'


### PR DESCRIPTION
The json output format has changed between nix
2.18 and nix 2.19, causing instantiate.sh to fail.

Given that the output format is unstable, and that
we are only interested in the output path of the
derivation, we can skip parsing the json output,
since nix-path-info will return only the path
if not called with the `--json` argument.

Closes #8
